### PR TITLE
Support for New ChatGPT Message Formats (Informational PR)

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,9 @@ The script handles various ChatGPT message types and formats them appropriately 
 * **Regular messages**: Standard user and assistant conversations
 * **Internal reasoning**: ChatGPT's thinking process appears as "ChatGPT (thinking)"
 * **Reasoning summaries**: Brief reasoning recaps appear as "ChatGPT (reasoning summary)"
+* **Tool calls**: ChatGPT initiating tool usage appears as "ChatGPT (tool call)"
+* **Tool execution**: ChatGPT executing tools appears as "ChatGPT (tool execution)"
+* **Tool results**: Tool response messages appear as "Tool (tool_name)"
 * **User context**: Profile and instruction context appears as "System (context)"
 
 This ensures that newer ChatGPT exports with internal reasoning are fully supported and clearly labeled in the markdown output.

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@ ChatGPT Conversations to Markdown is a Python script that converts your exported
 
 ## Features
 * Convert ChatGPT conversations stored in JSON format to Markdown
+* Support for new ChatGPT message formats including internal reasoning and user context
 * Customize user and assistant names using a configuration file
 * Include or exclude date in the output Markdown files
 * Customize the format of file names, dates, and message separators
@@ -48,5 +49,16 @@ python chatgpt_json_to_markdown.py
 ```
 All Done Buddy! You can access your files here: <output_directory>
 ```
+
+## Message Format Support
+
+The script handles various ChatGPT message types and formats them appropriately in the output:
+
+* **Regular messages**: Standard user and assistant conversations
+* **Internal reasoning**: ChatGPT's thinking process appears as "ChatGPT (thinking)"
+* **Reasoning summaries**: Brief reasoning recaps appear as "ChatGPT (reasoning summary)"
+* **User context**: Profile and instruction context appears as "System (context)"
+
+This ensures that newer ChatGPT exports with internal reasoning are fully supported and clearly labeled in the markdown output.
 
 Now you can easily read, share, or archive your ChatGPT conversations in a more human-readable format. Enjoy!

--- a/chatgpt_json_to_markdown.py
+++ b/chatgpt_json_to_markdown.py
@@ -53,23 +53,23 @@ def _get_author_name(message, config):
     """
     author_role = message["author"]["role"]
     base_name = config['user_name'] if author_role == "user" else config['assistant_name']
-    
+
     # Handle tool messages
     if author_role == "tool":
         tool_name = message["author"].get("name", "tool")
         return f"Tool ({tool_name})"
-    
+
     # Check for special content types
     content = message.get("content", {})
     recipient = message.get("recipient", "")
-    
+
     # Tool call detection
     if content.get("content_type") == "code":
         if recipient == "web":
             return f"{base_name} (tool call)"
         elif recipient == "web.run":
             return f"{base_name} (tool execution)"
-    
+
     # Other special content types
     if "thoughts" in content:
         return f"{base_name} (thinking)"
@@ -77,7 +77,7 @@ def _get_author_name(message, config):
         return f"{base_name} (reasoning summary)"
     elif content.get("content_type") == "user_editable_context":
         return "System (context)"
-    
+
     return base_name
 
 def _get_title(title, first_message):

--- a/chatgpt_json_to_markdown.py
+++ b/chatgpt_json_to_markdown.py
@@ -27,6 +27,21 @@ def _get_message_content(message):
         content = message["content"]["text"]
     elif "result" in message["content"]:
         content = message["content"]["result"]
+    elif "thoughts" in message["content"]:
+        # Handle ChatGPT's internal reasoning/thoughts format
+        thoughts = message["content"]["thoughts"]
+        content = "\n".join(
+            f"**{thought.get('summary', 'Thought')}**: {thought.get('content', '')}"
+            for thought in thoughts if isinstance(thought, dict)
+        )
+    elif message["content"].get("content_type") == "reasoning_recap":
+        # Handle reasoning recap messages
+        content = f"*{message['content'].get('content', 'Reasoning completed')}*"
+    elif message["content"].get("content_type") == "user_editable_context":
+        # Handle user context/profile messages - usually system context
+        profile = message["content"].get("user_profile", "")
+        instructions = message["content"].get("user_instructions", "")
+        content = f"*User Context*:\n{profile}\n{instructions}".strip()
     else:
         raise ValueError(f"Unknown message format: {message['content']}")
     

--- a/chatgpt_json_to_markdown.py
+++ b/chatgpt_json_to_markdown.py
@@ -54,8 +54,23 @@ def _get_author_name(message, config):
     author_role = message["author"]["role"]
     base_name = config['user_name'] if author_role == "user" else config['assistant_name']
     
+    # Handle tool messages
+    if author_role == "tool":
+        tool_name = message["author"].get("name", "tool")
+        return f"Tool ({tool_name})"
+    
     # Check for special content types
     content = message.get("content", {})
+    recipient = message.get("recipient", "")
+    
+    # Tool call detection
+    if content.get("content_type") == "code":
+        if recipient == "web":
+            return f"{base_name} (tool call)"
+        elif recipient == "web.run":
+            return f"{base_name} (tool execution)"
+    
+    # Other special content types
     if "thoughts" in content:
         return f"{base_name} (thinking)"
     elif content.get("content_type") == "reasoning_recap":


### PR DESCRIPTION
Thanks for this script!

I offer this as an "informational" PR. All changes were made by Claude Code. I directed the work, but did NOT do a careful human review of code or output. The new code works well on a large recent (2025-07-20) export I have covering conversations of different types. I believe the changes are useful, but more human testing and verification of operation would be appropriate before merging.

This PR is similar in intent to #5 but more comprehensive. It also targets a different message type for reasoning, which I found in my export of 2025-07-20.

The rest of this PR description was written by Claude Code.

## Overview

This PR adds support for newer ChatGPT export formats that include internal reasoning and user context, preventing conversion failures when processing recent ChatGPT exports. It also improves readability by using descriptive author names for different message types.

## Changes Made

### Code Changes (`chatgpt_json_to_markdown.py`)
- **New message format support**: Added handling for three new content types:
  - `thoughts` - ChatGPT's internal reasoning with summary and detailed content
  - `reasoning_recap` - Brief summaries like "Thought for 7 seconds"  
  - `user_editable_context` - User profile and instruction context
- **Tool interaction support**: Added comprehensive detection for ChatGPT's tool usage:
  - **Tool calls**: ChatGPT initiating tool usage appears as "**ChatGPT (tool call)**"
  - **Tool execution**: ChatGPT executing tools appears as "**ChatGPT (tool execution)**"
  - **Tool results**: Tool response messages appear as "**Tool (tool_name)**"
- **Descriptive author names**: Messages now display with clear labels:
  - Internal reasoning appears as "**ChatGPT (thinking)**"
  - Reasoning summaries appear as "**ChatGPT (reasoning summary)**"
  - User context appears as "**System (context)**"
- **Code organization**: Enhanced `_get_author_name()` helper function with recipient field analysis

### Documentation (`README.md`)
- Added new message format support to features list
- Added "Message Format Support" section explaining how different message types are labeled
- Documented tool interaction features (tool calls, execution, and results)
- Updated to reflect current capabilities

## Problem Solved
Before this change, the converter would crash with `ValueError: Unknown message format` when encountering newer ChatGPT exports that include internal reasoning. Now it successfully processes all message types while preserving the reasoning context in clearly labeled, readable output.

## Testing
Successfully processed a large ChatGPT export (4357+ conversations, 197MB) that previously failed due to these new message formats. All message types are now properly labeled and formatted in the markdown output.