### PR TITLE
Add per-message timestamps and file size validation

### DIFF
--- a/chatgpt-markdown-converter.html
+++ b/chatgpt-markdown-converter.html
@@ -182,6 +182,7 @@
                       ></path>
                     </svg>
                     <span x-text="zipFile?.name"></span>
+                    <span x-show="zipFile" class="text-gray-400 ml-2" x-text="zipFile ? `(${(zipFile.size / (1024*1024)).toFixed(1)} MB)` : ''"></span>
                   </span>
                 </p>
                 <p class="text-sm text-gray-500">ChatGPT export ZIP file</p>
@@ -377,7 +378,18 @@
                 />
                 <div>
                   <span class="font-medium text-gray-900">Include Dates</span>
-                  <p class="text-sm text-gray-500">Show timestamps</p>
+                  <p class="text-sm text-gray-500">Show conversation date</p>
+                </div>
+              </label>
+              <label class="flex items-center space-x-3 cursor-pointer">
+                <input
+                  type="checkbox"
+                  x-model="config.include_message_timestamps"
+                  class="w-5 h-5 text-indigo-600 rounded"
+                />
+                <div>
+                  <span class="font-medium text-gray-900">Per-Message Timestamps</span>
+                  <p class="text-sm text-gray-500">Show date and time on each message</p>
                 </div>
               </label>
             </div>
@@ -756,6 +768,7 @@
             use_collapsible_thinking: true,
             details_content_format: "markdown", // "markdown" | "html"
             include_date: true,
+            include_message_timestamps: true,
             starred_folder: "Starred",
             archived_folder: "Archived",
             regular_folder: "Regular",
@@ -776,8 +789,26 @@
           outputZip: null,
 
           async handleFileUpload(event) {
-            this.zipFile = event.target.files[0];
-            if (this.zipFile) console.log("ZIP loaded:", this.zipFile.name);
+            const file = event.target.files[0];
+            if (!file) return;
+
+            if (file.size > 2 * 1024 * 1024 * 1024) {
+              alert(
+                `This ZIP file is ${(file.size / (1024 * 1024 * 1024)).toFixed(1)} GB, ` +
+                `which exceeds the 2 GB browser limit.\n\n` +
+                `The web converter cannot process files this large due to browser memory constraints.\n\n` +
+                `Alternatives:\n` +
+                `1. Use the Python CLI tool (chatgpt_json_to_markdown.py) for large exports\n` +
+                `2. Extract the ZIP manually and point the Python tool at the directory\n` +
+                `3. Split your export into smaller ZIPs (each under 2 GB)`
+              );
+              event.target.value = "";
+              this.zipFile = null;
+              return;
+            }
+
+            this.zipFile = file;
+            console.log("ZIP loaded:", this.zipFile.name, `(${(file.size / (1024 * 1024)).toFixed(1)} MB)`);
           },
 
           // ON-DEMAND SEARCH: Find file starting with fileId (Python glob-style)
@@ -1027,6 +1058,11 @@
               } else if (error.message.includes("JSON")) {
                 errorMessage =
                   "Invalid JSON format in conversations.json. The file may be corrupted.";
+              } else if (error.message.includes("Corrupted zip") || error.message.includes("End of data reached")) {
+                errorMessage =
+                  "This ZIP file appears too large for browser-based processing. " +
+                  "Please use the Python CLI tool (chatgpt_json_to_markdown.py) for large exports, " +
+                  "or extract the ZIP manually and use directory mode.";
               } else {
                 errorMessage = `Error: ${error.message}`;
               }
@@ -1111,7 +1147,13 @@
                 dalleFolder,
                 conversationPath,
               );
-              if (content.trim()) md += `**${author}**:\n\n${content}\n\n`;
+              if (content.trim()) {
+                let tsStr = "";
+                if (this.config.include_message_timestamps && msg.create_time) {
+                  tsStr = ` <sub>${this.formatTimestamp(msg.create_time)}</sub>`;
+                }
+                md += `**${author}**:${tsStr}\n\n${content}\n\n`;
+              }
             }
 
             return md;

--- a/chatgpt_json_to_markdown.py
+++ b/chatgpt_json_to_markdown.py
@@ -410,8 +410,16 @@ def process_conversations(data, output_dir, config, input_base_path):
                 author_name = _get_author_name(message, config)
 
                 if not config.get('skip_empty_messages', True) or content.strip():
+                    # Build timestamp string if enabled
+                    timestamp_str = ""
+                    if config.get('include_message_timestamps', True):
+                        msg_time = message.get("create_time")
+                        if msg_time:
+                            ts_format = config.get('message_timestamp_format', '%m-%d-%Y %H:%M')
+                            timestamp_str = f" <sub>{datetime.fromtimestamp(msg_time).strftime(ts_format)}</sub>"
+
                     # Write author and content
-                    f.write(f"**{author_name}**:\n\n{content}{config['message_separator']}")
+                    f.write(f"**{author_name}**:{timestamp_str}\n\n{content}{config['message_separator']}")
 
 def main():
     config_path = Path("config.json")

--- a/config.json.example
+++ b/config.json.example
@@ -7,6 +7,8 @@
   "date_format": "%m-%d-%Y",
   "file_name_format": "{title}",
   "include_date": true,
+  "include_message_timestamps": true,
+  "message_timestamp_format": "%m-%d-%Y %H:%M",
   "message_separator": "\n\n",
   "skip_empty_messages": true,
   "use_frontmatter": true,

--- a/setup.py
+++ b/setup.py
@@ -178,6 +178,8 @@ def run_setup():
     config['date_format'] = '%m-%d-%Y'
     config['file_name_format'] = '{title}'
     config['include_date'] = True
+    config['include_message_timestamps'] = True
+    config['message_timestamp_format'] = '%m-%d-%Y %H:%M'
     config['message_separator'] = '\n\n'
     config['skip_empty_messages'] = True
 


### PR DESCRIPTION
## Summary
This PR enhances the converter with per-message timestamp support and adds file size validation to prevent browser memory issues when processing large ZIP files.

## Key Changes

- **Per-Message Timestamps**: Added a new `include_message_timestamps` configuration option that displays the date and time for each individual message in conversations, separate from the conversation-level date
  - Updated UI to include a new checkbox for "Per-Message Timestamps"
  - Modified message rendering in both web and Python versions to append timestamps as subscript text
  - Added `message_timestamp_format` config option for customizable timestamp formatting

- **File Size Validation**: Implemented a 2 GB browser limit check in the file upload handler
  - Displays a user-friendly alert when files exceed the limit
  - Provides alternative solutions (Python CLI tool, manual extraction, splitting exports)
  - Prevents corrupted zip errors by catching oversized files early

- **UI Improvements**:
  - Display uploaded ZIP file size in MB next to the filename
  - Updated "Include Dates" label from "Show timestamps" to "Show conversation date" for clarity

- **Error Handling**: Added specific error message for corrupted/oversized ZIP files during processing

- **Configuration Updates**: Updated `config.json.example` and `setup.py` with new timestamp-related defaults

## Implementation Details

- Timestamps are formatted as subscript HTML (`<sub>`) elements for visual distinction
- File size validation occurs before processing to fail fast
- Both web (JavaScript) and Python CLI implementations support the new feature consistently
- Default behavior includes per-message timestamps (can be disabled via config)