### PR TITLE
Add line ending normalization and configurable output line endings

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,22 @@ The `file_name_format` key in `config.json` controls how output filenames are co
 
 > **Note:** Including `{id}` in your format is recommended. It ensures conversations with identical titles never overwrite each other.
 
+### Line Endings
+
+The `line_endings` key controls the line ending style written to `.md` files:
+
+| Value | Line Ending | Use When |
+|-------|-------------|----------|
+| `native` | OS default (`\r\n` on Windows, `\n` on macOS/Linux) | Default — matches your OS |
+| `lf` | `\n` (Unix) | Cross-platform vaults, Git repos, macOS/Linux Obsidian |
+| `crlf` | `\r\n` (Windows) | Windows-only vaults where tools expect CRLF |
+
+```json
+"line_endings": "lf"
+```
+
+> **Note:** `lf` is recommended for Obsidian vaults that are synced or version-controlled, as it avoids platform-specific diffs.
+
 ## 📥 Getting Your ChatGPT Data
 
 1. Go to [ChatGPT Settings](https://chatgpt.com/settings) → **Data Controls**

--- a/chatgpt_json_to_markdown.py
+++ b/chatgpt_json_to_markdown.py
@@ -213,6 +213,8 @@ def _process_message_parts(parts, input_base_path, output_base, config, conversa
     content = "\n".join(filter(None, content_pieces))
     # Strip Unicode Private Use Area characters used as metadata delimiters (fixes #8)
     content = re.sub(r'[\ue000-\uf8ff]', '', content)
+    # Normalize line endings — pasted content may carry \r\n or bare \r from external sources
+    content = content.replace('\r\n', '\n').replace('\r', '\n')
     return content, attachments
 
 def _get_message_content(message, input_base_path, output_base, config, conversation_path):
@@ -267,10 +269,12 @@ def _get_message_content(message, input_base_path, output_base, config, conversa
         return f"```\n{code_text}\n```", []
 
     elif "text" in content_obj:
-        return re.sub(r'[\ue000-\uf8ff]', '', content_obj["text"]), []
+        text = re.sub(r'[\ue000-\uf8ff]', '', content_obj["text"])
+        return text.replace('\r\n', '\n').replace('\r', '\n'), []
 
     elif "result" in content_obj:
-        return re.sub(r'[\ue000-\uf8ff]', '', content_obj["result"]), []
+        text = re.sub(r'[\ue000-\uf8ff]', '', content_obj["result"])
+        return text.replace('\r\n', '\n').replace('\r', '\n'), []
 
     else:
         # Unknown format, try to extract something useful
@@ -425,7 +429,8 @@ def process_conversations(data, output_dir, config, input_base_path):
         file_path = conversation_dir / file_name
 
         # Write messages to file
-        with open(file_path, "w", encoding="utf-8") as f:
+        newline = {'lf': '\n', 'crlf': '\r\n'}.get(config.get('line_endings', 'native'))
+        with open(file_path, "w", encoding="utf-8", newline=newline) as f:
             # Write frontmatter
             if config.get('use_frontmatter', True):
                 frontmatter = generate_frontmatter(inferred_title, create_time, update_time, config)

--- a/config.json.example
+++ b/config.json.example
@@ -19,5 +19,6 @@
   "include_message_timestamps": true,
   "message_timestamp_format": "%m-%d-%Y %H:%M",
   "message_separator": "\n\n",
-  "skip_empty_messages": true
+  "skip_empty_messages": true,
+  "line_endings": "native"
 }

--- a/setup.py
+++ b/setup.py
@@ -183,6 +183,7 @@ def run_setup():
     config['message_timestamp_format'] = '%m-%d-%Y %H:%M'
     config['message_separator'] = '\n\n'
     config['skip_empty_messages'] = True
+    config['line_endings'] = 'native'
 
     # Save config
     config_path = Path('config.json')


### PR DESCRIPTION
## Summary

- Normalizes `\r\n` and bare `\r` in message content before writing, so pasted Windows text or legacy Mac content doesn't produce mixed line endings in the output markdown
- Adds a `line_endings` config key (`"native"` / `"lf"` / `"crlf"`) that controls what Python's `open()` writes to disk
- Documents the option in README with a reference table and an `lf`-recommended note for synced/version-controlled vaults
- Adds `"line_endings": "native"` to `setup.py` defaults and `config.json.example`

## Test plan

- [x] Default (`"native"`) produces OS-native line endings (CRLF on Windows)
- [x] `"line_endings": "lf"` — all output `.md` files contain only `\n`
- [x] `"line_endings": "crlf"` — all output `.md` files contain `\r\n`
- [x] Conversations containing pasted Windows text (with `\r\n`) render correctly with uniform line endings in the output