### PR TITLE
Fix line ending normalization missing from code blocks and other content branches

### DIFF
--- a/chatgpt_json_to_markdown.py
+++ b/chatgpt_json_to_markdown.py
@@ -233,6 +233,7 @@ def _get_message_content(message, input_base_path, output_base, config, conversa
     elif content_type == "reasoning_recap":
         # Handle reasoning recap messages
         recap_text = content_obj.get('content', 'Reasoning completed')
+        recap_text = recap_text.replace('\r\n', '\n').replace('\r', '\n')
         if config.get('use_obsidian_callouts', True):
             content = f"> [!info] Reasoning Summary\n> {recap_text}"
         else:
@@ -246,7 +247,7 @@ def _get_message_content(message, input_base_path, output_base, config, conversa
         for thought in thoughts:
             if isinstance(thought, dict):
                 summary = thought.get('summary', 'Thought')
-                thought_content = thought.get('content', '')
+                thought_content = thought.get('content', '').replace('\r\n', '\n').replace('\r', '\n')
                 thought_lines.append(f"**{summary}**: {thought_content}")
 
         content = "\n".join(thought_lines)
@@ -256,8 +257,8 @@ def _get_message_content(message, input_base_path, output_base, config, conversa
 
     elif content_type == "user_editable_context":
         # Handle user context/profile messages
-        profile = content_obj.get("user_profile", "")
-        instructions = content_obj.get("user_instructions", "")
+        profile = content_obj.get("user_profile", "").replace('\r\n', '\n').replace('\r', '\n')
+        instructions = content_obj.get("user_instructions", "").replace('\r\n', '\n').replace('\r', '\n')
         content = f"*User Context*:\n{profile}\n{instructions}".strip()
         if config.get('use_obsidian_callouts', True):
             content = f"> [!abstract] User Context\n> " + content.replace("\n", "\n> ")
@@ -266,6 +267,7 @@ def _get_message_content(message, input_base_path, output_base, config, conversa
     elif content_type == "code":
         # Handle code content
         code_text = content_obj.get('text', content_obj.get('content', ''))
+        code_text = code_text.replace('\r\n', '\n').replace('\r', '\n')
         return f"```\n{code_text}\n```", []
 
     elif "text" in content_obj:
@@ -279,7 +281,7 @@ def _get_message_content(message, input_base_path, output_base, config, conversa
     else:
         # Unknown format, try to extract something useful
         if isinstance(content_obj, dict):
-            return str(content_obj.get('content', '')), []
+            return str(content_obj.get('content', '')).replace('\r\n', '\n').replace('\r', '\n'), []
         return "", []
 
 def _get_author_name(message, config):


### PR DESCRIPTION
  ## Summary

  Follow-up to #26. The previous fix normalized `\r\n` and bare `\r` in
  the `text`, `result`, and `parts`-based content paths, but missed
  several other branches in `_get_message_content()`.

  The most impactful miss was `content_type == "code"` — code blocks are
  the most common source of Windows line endings, since users paste code
  snippets that carry `\r\n` from their editor or clipboard.

  Adds normalization to all remaining branches:
  - `code` — fenced code blocks (the confirmed real-world failure case)
  - `reasoning_recap`
  - `thoughts` (per-thought `content` field)
  - `user_editable_context` (`user_profile` and `user_instructions` fields)
  - fallback `else` branch

  ## Test plan

  - [x] Converted a file containing code blocks with `\r\n` in the source JSON — output now has uniform LF endings
  throughout, including inside fenced code blocks
  - [x] All other output files continue to produce uniform line endings matching the `line_endings` config setting