### PR TITLE
Add configurable message formatting options

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,46 @@ The `line_endings` key controls the line ending style written to `.md` files:
 
 > **Note:** `lf` is recommended for Obsidian vaults that are synced or version-controlled, as it avoids platform-specific diffs.
 
+### Message Formatting Options
+
+These options control how message headers, callouts, and timestamps are rendered. All defaults preserve the original output behavior — none of these need to be set unless you want to change something.
+
+#### Author Names
+
+| Key | Default | Notes |
+|-----|---------|-------|
+| `assistant_name` | `"ChatGPT"` | Display name for assistant messages. Set to `""` to suppress the assistant header entirely. |
+
+`user_name` (set during setup) behaves the same way — set to `""` to suppress the user header.
+
+#### Callout Types
+
+When `use_obsidian_callouts` is enabled, internal reasoning and reasoning summary blocks are rendered as Obsidian callouts. These options let you change the callout type or disable the callout entirely.
+
+| Key | Default | Notes |
+|-----|---------|-------|
+| `reasoning_callout_type` | `"note"` | Callout type for internal reasoning blocks. `""` = plain bold header instead. |
+| `reasoning_callout_state` | `"static"` | `"collapsed"` (closed by default) or `"expanded"` (open, collapsible) |
+| `reasoning_summary_callout_type` | `"info"` | Callout type for reasoning summary blocks. `""` = plain bold header instead. |
+| `reasoning_summary_callout_state` | `"static"` | `"collapsed"` or `"expanded"` |
+| `prompt_callout_type` | `""` | Wrap user prompts in a callout of this type. `""` = plain bold header (default). |
+| `response_callout_type` | `""` | Wrap assistant responses in a callout of this type. `""` = plain bold header (default). |
+| `tool_callout_type` | `""` | Wrap tool output in a callout of this type. `""` = plain bold header (default). |
+| `tool_callout_state` | `"static"` | `"collapsed"` or `"expanded"` |
+
+When a callout is used for a message, the callout title serves as the author header — no separate bold header is written.
+
+**Obsidian custom callout types** allow you to style each block independently with a CSS snippet. For example, setting `prompt_callout_type` to `"ai-prompt"` and targeting `[data-callout="ai-prompt"]` in CSS lets you style user prompts to look like chat bubbles. Setting a callout type and using `display: none` in CSS is also a clean way to hide sections (such as tool output) without removing them from the file.
+
+#### Timestamps
+
+| Key | Default | Notes |
+|-----|---------|-------|
+| `timestamp_tag` | `"sub"` | HTML tag wrapping the timestamp. `"time"` for semantic markup, `""` for no tag. |
+| `timestamp_position` | `"header"` | `"header"` places the timestamp on the line after the author header. `"footer"` places it after the message body. |
+
+Timestamps stay attached to their message block regardless of position — including inside callout blocks when `"footer"` is used.
+
 ## 📥 Getting Your ChatGPT Data
 
 1. Go to [ChatGPT Settings](https://chatgpt.com/settings) → **Data Controls**

--- a/chatgpt_json_to_markdown.py
+++ b/chatgpt_json_to_markdown.py
@@ -661,14 +661,19 @@ def process_conversations(data, output_dir, config, input_base_path):
                             block = content
 
                     else:
-                        # Standard mode: timestamp always on its own line after the
-                        # header so it remains visible even when the header is hidden.
-                        header_parts = []
+                        # Standard mode: timestamp inline with the bold header, matching
+                        # original output. When the header is suppressed (empty author
+                        # name), the timestamp is written on its own line so it remains
+                        # visible.
                         if author_name and not suppress_header:
-                            header_parts.append(f"**{author_name}**:")
-                        if timestamp_str and timestamp_position == 'header':
-                            header_parts.append(timestamp_str)
-                        header = "\n".join(header_parts) + "\n\n" if header_parts else ""
+                            if timestamp_str and timestamp_position == 'header':
+                                header = f"**{author_name}**: {timestamp_str}\n\n"
+                            else:
+                                header = f"**{author_name}**:\n\n"
+                        elif timestamp_str and timestamp_position == 'header':
+                            header = f"{timestamp_str}\n\n"
+                        else:
+                            header = ""
                         footer = f"\n\n{timestamp_str}" if timestamp_str and timestamp_position == 'footer' else ""
                         block = f"{header}{content}{footer}"
 

--- a/chatgpt_json_to_markdown.py
+++ b/chatgpt_json_to_markdown.py
@@ -217,6 +217,14 @@ def _process_message_parts(parts, input_base_path, output_base, config, conversa
     content = content.replace('\r\n', '\n').replace('\r', '\n')
     return content, attachments
 
+def _callout_collapse_marker(state):
+    """Return the Obsidian callout collapse suffix for a given state string."""
+    if state == 'collapsed':
+        return '-'
+    elif state == 'expanded':
+        return '+'
+    return ''
+
 def _get_message_content(message, input_base_path, output_base, config, conversation_path):
     """
     Extracts the content of a message from the message object,
@@ -234,7 +242,12 @@ def _get_message_content(message, input_base_path, output_base, config, conversa
         # Handle reasoning recap messages
         recap_text = content_obj.get('content', 'Reasoning completed')
         if config.get('use_obsidian_callouts', True):
-            content = f"> [!info] Reasoning Summary\n> {recap_text}"
+            callout_type = config.get('reasoning_summary_callout_type', 'info')
+            if callout_type:
+                collapse = _callout_collapse_marker(config.get('reasoning_summary_callout_state', 'static'))
+                content = f"> [!{callout_type}]{collapse} Reasoning Summary\n> {recap_text}"
+            else:
+                content = recap_text
         else:
             content = f"*{recap_text}*"
         return content, []
@@ -251,7 +264,10 @@ def _get_message_content(message, input_base_path, output_base, config, conversa
 
         content = "\n".join(thought_lines)
         if config.get('use_obsidian_callouts', True) and content:
-            content = f"> [!note] Internal Reasoning\n> " + content.replace("\n", "\n> ")
+            callout_type = config.get('reasoning_callout_type', 'note')
+            if callout_type:
+                collapse = _callout_collapse_marker(config.get('reasoning_callout_state', 'static'))
+                content = f"> [!{callout_type}]{collapse} Internal Reasoning\n> " + content.replace("\n", "\n> ")
         return content, []
 
     elif content_type == "user_editable_context":
@@ -287,7 +303,7 @@ def _get_author_name(message, config):
     Determines the appropriate author name based on message type and role.
     """
     author_role = message.get("author", {}).get("role", "unknown")
-    base_name = config['user_name'] if author_role == "user" else config['assistant_name']
+    base_name = config.get('user_name', '') if author_role == "user" else config.get('assistant_name', 'ChatGPT')
 
     # Handle tool messages
     if author_role == "tool":
@@ -308,9 +324,9 @@ def _get_author_name(message, config):
 
     # Other special content types
     if "thoughts" in content:
-        return f"{base_name} (thinking)"
+        return "Internal Reasoning"
     elif content_type == "reasoning_recap":
-        return f"{base_name} (reasoning summary)"
+        return "Reasoning Summary"
     elif content_type == "user_editable_context":
         return "System (context)"
 
@@ -553,7 +569,8 @@ def process_conversations(data, output_dir, config, input_base_path):
             # Write messages
             for message in messages:
                 # Skip system messages
-                if message.get("author", {}).get("role") == "system":
+                author_role = message.get("author", {}).get("role", "unknown")
+                if author_role == "system":
                     continue
 
                 content, attachments = _get_message_content(
@@ -565,6 +582,28 @@ def process_conversations(data, output_dir, config, input_base_path):
                 )
                 author_name = _get_author_name(message, config)
 
+                # Detect reasoning/recap messages — they carry their own callout
+                # headers and must not be wrapped by response_callout_type.
+                msg_content = message.get("content", {})
+                msg_content_type = msg_content.get("content_type", "")
+                is_reasoning = "thoughts" in msg_content
+                is_recap = msg_content_type == "reasoning_recap"
+
+                # Suppress the bold header for reasoning/recap when their own
+                # callout is active — the callout title serves as the header.
+                if is_reasoning:
+                    suppress_header = bool(
+                        config.get('use_obsidian_callouts', True) and
+                        config.get('reasoning_callout_type', 'note')
+                    )
+                elif is_recap:
+                    suppress_header = bool(
+                        config.get('use_obsidian_callouts', True) and
+                        config.get('reasoning_summary_callout_type', 'info')
+                    )
+                else:
+                    suppress_header = False
+
                 if not config.get('skip_empty_messages', True) or content.strip():
                     # Build timestamp string if enabled
                     timestamp_str = ""
@@ -572,10 +611,68 @@ def process_conversations(data, output_dir, config, input_base_path):
                         msg_time = normalize_timestamp(message.get("create_time"))
                         if msg_time:
                             ts_format = config.get('message_timestamp_format', '%m-%d-%Y %H:%M')
-                            timestamp_str = f" <sub>{datetime.fromtimestamp(msg_time).strftime(ts_format)}</sub>"
+                            ts_text = datetime.fromtimestamp(msg_time).strftime(ts_format)
+                            tag = config.get('timestamp_tag', 'sub')
+                            timestamp_str = f"<{tag}>{ts_text}</{tag}>" if tag else ts_text
 
-                    # Write author and content
-                    f.write(f"**{author_name}**:{timestamp_str}\n\n{content}{config['message_separator']}")
+                    timestamp_position = config.get('timestamp_position', 'header')
+
+                    # Determine prompt/response/tool callout type and collapse state.
+                    # Reasoning/recap messages are excluded — they manage their own callouts.
+                    if author_role == "user":
+                        msg_callout_type = config.get('prompt_callout_type', '')
+                        msg_callout_state = 'static'
+                    elif author_role == "tool":
+                        msg_callout_type = config.get('tool_callout_type', '')
+                        msg_callout_state = config.get('tool_callout_state', 'static')
+                    elif author_role == "assistant" and not (is_reasoning or is_recap):
+                        msg_callout_type = config.get('response_callout_type', '')
+                        msg_callout_state = 'static'
+                    else:
+                        msg_callout_type = ''
+                        msg_callout_state = 'static'
+
+                    if msg_callout_type:
+                        # Prompt/response/tool callout mode: author name is the callout title.
+                        collapse = _callout_collapse_marker(msg_callout_state)
+                        title_part = f" {author_name}" if author_name else ""
+                        callout_header = f"> [!{msg_callout_type}]{collapse}{title_part}"
+                        callout_body = "> " + content.replace("\n", "\n> ")
+                        if timestamp_str and timestamp_position == 'header':
+                            block = f"{callout_header}\n> {timestamp_str}\n> \n{callout_body}"
+                        else:
+                            block = f"{callout_header}\n{callout_body}"
+                        if timestamp_str and timestamp_position == 'footer':
+                            block += f"\n> \n> {timestamp_str}"
+
+                    elif suppress_header and timestamp_str:
+                        # Reasoning/recap with an active callout and a timestamp:
+                        # inject timestamp into the callout so it stays attached.
+                        # content is guaranteed to be a callout block here.
+                        first_nl = content.find('\n')
+                        if first_nl != -1:
+                            cl1 = content[:first_nl]
+                            rest = content[first_nl:]  # starts with \n
+                            if timestamp_position == 'header':
+                                block = f"{cl1}\n> {timestamp_str}\n> {rest}"
+                            else:  # footer
+                                block = f"{content}\n> \n> {timestamp_str}"
+                        else:
+                            block = content
+
+                    else:
+                        # Standard mode: timestamp always on its own line after the
+                        # header so it remains visible even when the header is hidden.
+                        header_parts = []
+                        if author_name and not suppress_header:
+                            header_parts.append(f"**{author_name}**:")
+                        if timestamp_str and timestamp_position == 'header':
+                            header_parts.append(timestamp_str)
+                        header = "\n".join(header_parts) + "\n\n" if header_parts else ""
+                        footer = f"\n\n{timestamp_str}" if timestamp_str and timestamp_position == 'footer' else ""
+                        block = f"{header}{content}{footer}"
+
+                    f.write(f"{block}{config['message_separator']}")
 
 def migrate_config(config, config_path):
     """Migrate config.json to the latest version, saving changes back to disk."""

--- a/config.json.example
+++ b/config.json.example
@@ -20,5 +20,15 @@
   "message_timestamp_format": "%m-%d-%Y %H:%M",
   "message_separator": "\n\n",
   "skip_empty_messages": true,
-  "line_endings": "native"
+  "line_endings": "native",
+  "reasoning_callout_type": "note",
+  "reasoning_callout_state": "static",
+  "reasoning_summary_callout_type": "info",
+  "reasoning_summary_callout_state": "static",
+  "prompt_callout_type": "",
+  "response_callout_type": "",
+  "tool_callout_type": "",
+  "tool_callout_state": "static",
+  "timestamp_tag": "sub",
+  "timestamp_position": "header"
 }

--- a/setup.py
+++ b/setup.py
@@ -184,6 +184,16 @@ def run_setup():
     config['message_separator'] = '\n\n'
     config['skip_empty_messages'] = True
     config['line_endings'] = 'native'
+    config['reasoning_callout_type'] = 'note'
+    config['reasoning_callout_state'] = 'static'
+    config['reasoning_summary_callout_type'] = 'info'
+    config['reasoning_summary_callout_state'] = 'static'
+    config['prompt_callout_type'] = ''
+    config['response_callout_type'] = ''
+    config['tool_callout_type'] = ''
+    config['tool_callout_state'] = 'static'
+    config['timestamp_tag'] = 'sub'
+    config['timestamp_position'] = 'header'
 
     # Save config
     config_path = Path('config.json')


### PR DESCRIPTION
Introduces a set of optional config keys that let users customize how messages are rendered in the generated Markdown. All new keys ship with defaults that preserve the existing output, so current `config.json` files continue to work without modification.

### New config options

**Callouts** are controlled by paired configuration keys:

- `*_callout_type` — specifies the block callout type
  - Any built-in type: `note`, `info`, `tip`, `success`, etc.
  - Any custom type: `ai-prompt`, `ai-reasoning`, `ai-reasoning-summary`, `ai-tool`, etc.
  - `""` disables the callout and renders plain Markdown
- `*_callout_state` — controls collapsibility
  - `"static"` → not collapsible
  - `"collapsed"` → collapsible, collapsed by default
  - `"expanded"` → collapsible, expanded by default
  - The user `prompt` and assistant `response` are static and cannot be collapsed

**Timestamp** rendering

- `timestamp_tag` — specifies the HTML tag that will wrap the timestamp text
  - Common HTML tags: `"div"`, `"span"`, `"sub"`, `"sup"`, `"time"`, etc.
  - Obsidian may strip out unsupported tags
  - `""` disables the wrap and outputs plain inline text
- `timestamp_position` — specifies where the timestamp appears
  - `"header"` → before the block content
  - `"footer"` → after the block content
  - For callout blocks, the timestamp will be positioned inside the callout

**Header** rendering

- Content blocks have headers specific to the content type.
- Blocks wrapped in callouts automatically suppress the plain Markdown header, because the callout title acts as the header
- **Prompt** and **Response** headers may be suppressed even when callouts are not used
  - **Prompt** content normally has the header: `**{user_name}**: `
    - Set `user_name` to `""` to suppress the header
  - **Response** content uses the header: `**{assistant_name}**: `
    - Set `assistant_name` to `""` to suppress the header

**Defaults**

All default values are chosen to preserve the converter’s existing output. With a default configuration, generated Markdown remains consistent with prior behavior, so existing `config.json` files do not require changes.

For new configurations, the following alternatives may be preferable:

- Setting `*_callout_state` to `"collapsed"` can improve readability by reducing visual noise from expanded blocks
- Using `"time"` for `timestamp_tag` provides more semantic HTML, and is supported by Obsidian.

| Property | Default Value |
|---|---|
| `prompt_callout_type`             | `""`       |
| `prompt_callout_type`             | `""`       |
| `response_callout_type`           | `""`       |
| `reasoning_callout_type`          | `"note"`   |
| `reasoning_callout_state`         | `"static"` |
| `reasoning_summary_callout_type`  | `"info"`   |
| `reasoning_summary_callout_state` | `"static"` |
| `tool_callout_type`               | `""`       |
| `tool_callout_state`              | `"static"` |
| `timestamp_tag`                   | `"sub"`    |
| `timestamp_position`              | `"header"` |

## Behaviour changes with default config

- Reasoning/recap headers suppressed when their callout is active. Previously, reasoning and reasoning-summary blocks rendered a bold-text header (e.g. `**ChatGPT (thinking)**:`) even when they were already wrapped in a callout, making the callout title and the bold header redundant. With defaults, the bold header is now suppressed when the callout is in use.
- Reasoning header text fixed to `Internal Reasoning` / `Reasoning Summary` rather than being derived from `assistant_name`. This prevents a blank header if `assistant_name` is `""` and aligns the header text with the callout title it replaces.
- Timestamp remains inline with the bold author header (e.g. `**ChatGPT**: 04-10-2026 12:34`) when callouts are not used. When the header is suppressed, the timestamp is written on its own line so it remains visible. When a block is wrapped in a callout, the timestamp is moved to the callout body.