### PR TITLE
Add callout support for tool call and tool execution message nodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ When `use_obsidian_callouts` is enabled, internal reasoning and reasoning summar
 | `reasoning_summary_callout_state` | `"static"` | `"collapsed"` or `"expanded"` |
 | `prompt_callout_type` | `""` | Wrap user prompts in a callout of this type. `""` = plain bold header (default). |
 | `response_callout_type` | `""` | Wrap assistant responses in a callout of this type. `""` = plain bold header (default). |
-| `tool_callout_type` | `""` | Wrap tool output in a callout of this type. `""` = plain bold header (default). |
+| `tool_callout_type` | `""` | Wrap all tool-related messages in a callout of this type. `""` = plain bold header (default). |
 | `tool_callout_state` | `"static"` | `"collapsed"` or `"expanded"` |
 
 When a callout is used for a message, the callout title serves as the author header — no separate bold header is written.

--- a/chatgpt_json_to_markdown.py
+++ b/chatgpt_json_to_markdown.py
@@ -320,9 +320,9 @@ def _get_author_name(message, config):
     # Tool call detection
     if content_type == "code":
         if recipient == "web":
-            return f"{base_name} (tool call)"
+            return "Tool Call"
         elif recipient == "web.run":
-            return f"{base_name} (tool execution)"
+            return "Tool Execution"
 
     # Other special content types
     if "thoughts" in content:
@@ -588,6 +588,7 @@ def process_conversations(data, output_dir, config, input_base_path):
                 # headers and must not be wrapped by response_callout_type.
                 msg_content = message.get("content", {})
                 msg_content_type = msg_content.get("content_type", "")
+                msg_recipient = message.get("recipient", "")
                 is_reasoning = "thoughts" in msg_content
                 is_recap = msg_content_type == "reasoning_recap"
 
@@ -625,6 +626,12 @@ def process_conversations(data, output_dir, config, input_base_path):
                         msg_callout_type = config.get('prompt_callout_type', '')
                         msg_callout_state = 'static'
                     elif author_role == "tool":
+                        msg_callout_type = config.get('tool_callout_type', '')
+                        msg_callout_state = config.get('tool_callout_state', 'static')
+                    elif author_role == "assistant" and msg_content_type == "code" and msg_recipient == "web":
+                        msg_callout_type = config.get('tool_callout_type', '')
+                        msg_callout_state = config.get('tool_callout_state', 'static')
+                    elif author_role == "assistant" and msg_content_type == "code" and msg_recipient == "web.run":
                         msg_callout_type = config.get('tool_callout_type', '')
                         msg_callout_state = config.get('tool_callout_state', 'static')
                     elif author_role == "assistant" and not (is_reasoning or is_recap):


### PR DESCRIPTION
## Summary

- Tool call (`content_type: "code"`, `recipient: "web"`) and tool execution (`content_type: "code"`, `recipient: "web.run"`) nodes previously fell through to `response_callout_type`, silently suppressing callout formatting when that key was unset
- Both types now use the existing `tool_callout_type` / `tool_callout_state` config keys — all tool-related messages share a single config pair, distinguished in the output by their header title ("Tool Call", "Tool Execution", "Tool (name)")
- Fixes `_get_author_name` to return `"Tool Call"` / `"Tool Execution"` for these types, consistent with the existing `"Internal Reasoning"` / `"Reasoning Summary"` pattern and eliminating the leading-space artifact when `assistant_name` is empty

 ## Test plan

- [x] Tool call nodes render as `> [!{tool_callout_type}]{state} Tool Call` when `tool_callout_type` is set
- [x] Tool execution nodes render as `> [!{tool_callout_type}]{state} Tool Execution` when `tool_callout_type` is set
- [x] Both fall back to the standard bold header when `tool_callout_type` is empty (existing behaviour preserved)
- [x] All three tool types (role: tool, tool call, tool execution) share the same callout type/state

  🤖 Generated with [Claude Code](https://claude.com/claude-code)