### PR TITLE
Fix prompt/response/tool callouts ignoring use_obsidian_callouts

### DIFF
--- a/chatgpt_json_to_markdown.py
+++ b/chatgpt_json_to_markdown.py
@@ -634,6 +634,9 @@ def process_conversations(data, output_dir, config, input_base_path):
                         msg_callout_type = ''
                         msg_callout_state = 'static'
 
+                    if not config.get('use_obsidian_callouts', True):
+                        msg_callout_type = ''
+
                     if msg_callout_type:
                         # Prompt/response/tool callout mode: author name is the callout title.
                         collapse = _callout_collapse_marker(msg_callout_state)


### PR DESCRIPTION
When `use_obsidian_callouts` was `false`, `prompt_callout_type`, `response_callout_type`, and `tool_callout_type` were still applied if set to a non-empty value. Added a guard after the callout type selection block that zeroes out `msg_callout_type` when callouts are disabled, ensuring all message types respect the setting.