### PR TITLE
Fix `get_relative_asset_path` using hardcoded `.parent.parent` depth

### DIFF
--- a/organize.py
+++ b/organize.py
@@ -1,3 +1,4 @@
+import os
 from pathlib import Path
 from datetime import datetime
 
@@ -135,15 +136,9 @@ def get_relative_asset_path(conversation_path, asset_path):
     conversation_path = Path(conversation_path)
     asset_path = Path(asset_path)
 
-    # Calculate relative path from conversation file to asset
-    try:
-        rel_path = asset_path.relative_to(conversation_path.parent.parent)
-        return str(rel_path).replace('\\', '/')  # Use forward slashes for markdown
-    except ValueError:
-        # If relative path fails, try using os.path.relpath
-        import os
-        rel = os.path.relpath(asset_path, conversation_path.parent)
-        return rel.replace('\\', '/')
+    # Relative path from the conversation file's directory to the asset
+    rel = os.path.relpath(asset_path, conversation_path.parent)
+    return rel.replace('\\', '/')
 
 def create_organization_summary(conversations, config, output_base):
     """


### PR DESCRIPTION
The previous `try`/`except` attempted `asset_path.relative_to(conversation_path.parent.parent)`, going up two directory levels regardless of organization mode. In `flat` mode this succeeded but returned a vault-rooted path (e.g. `ChatGPT/Assets/Images/file.jpg`) instead of the correct file-relative path (`Assets/Images/file.jpg`). In `category`/`date`/`hybrid` modes the `relative_to` call failed and fell through to the correct `os.path.relpath` fallback — but `flat` mode never reached it.

Fix: remove the `relative_to` attempt entirely and always use `os.path.relpath`, which computes the correct relative path for any nesting depth without assumptions. Affects all attachment types (user images, DALL-E, audio).